### PR TITLE
Add Implicit Connection with Secure Data

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -144,7 +144,8 @@ FTP.prototype.connect = function(options) {
   }
 
   this._socket = socket;
-  if (this.options.secure === 'implicit')
+  if (this.options.secure === 'implicit' ||
+      this.options.secure === 'implicit_secure')
     socket = tls.connect(secureOptions, onconnect);
   else {
     socket.once('connect', onconnect);
@@ -210,7 +211,8 @@ FTP.prototype.connect = function(options) {
         // about authorized use, other limits, etc.
         self.emit('greeting', text);
 
-        if (self.options.secure && self.options.secure !== 'implicit') {
+        if (self.options.secure && self.options.secure !== 'implicit' &&
+            self.options.secure !== 'implicit_secure') {
           cmd = 'AUTH TLS';
           self._send(cmd, reentry, true);
         } else {
@@ -248,8 +250,13 @@ FTP.prototype.connect = function(options) {
           cmd = 'OPTS';
           self._send('OPTS UTF8 ON', reentry, true);
         } else {
-          cmd = 'TYPE';
-          self._send('TYPE I', reentry, true);
+          if (self.options.secure === 'implicit_secure' && !self.nowSecure) {
+            cmd = 'PBSZ';
+            self._send('PBSZ 0', reentry, true);
+          } else {
+            cmd = 'TYPE';
+            self._send('TYPE I', reentry, true);
+          }
         }
       } else if (cmd === 'OPTS') { // ignore OPTS UTF8 result
         cmd = 'TYPE';
@@ -258,6 +265,10 @@ FTP.prototype.connect = function(options) {
         self.emit('ready');
       else if (cmd === 'PBSZ') {
         cmd = 'PROT';
+        if (self.options.secure === 'implicit_secure') {
+          cmd = 'FEAT';
+          self.nowSecure = true;
+        }
         self._send('PROT P', reentry, true);
       } else if (cmd === 'PROT') {
         cmd = 'USER';
@@ -961,7 +972,8 @@ FTP.prototype._pasvConnect = function(ip, port, cb) {
 
   socket.once('connect', function() {
     self._debug&&self._debug('[connection] PASV socket connected');
-    if (self.options.secure === true) {
+    if (self.options.secure === true ||
+        self.options.secure === 'implicit_secure') {
       self.options.secureOptions.socket = socket;
       self.options.secureOptions.session = self._socket.getSession();
       //socket.removeAllListeners('error');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@icetee/ftp",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "author": "Tamás András Horváth <htomy92@gmail.com>",
   "contributors": [
     "Brian White <mscdex@mscdex.net>"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@icetee/ftp",
-  "version": "1.0.3",
+  "version": "1.0.2",
   "author": "Tamás András Horváth <htomy92@gmail.com>",
   "contributors": [
     "Brian White <mscdex@mscdex.net>"


### PR DESCRIPTION
Currently a connection can be made with the "Implicit" option. However the data being transferred is not encrypted and an error would be passed down from the server

> 522 Data connections must be encrypted

This change would allow a connection with both an "Implicit" connection type and "Secure" data.