### PR TITLE
Fixed reentry

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -908,7 +908,7 @@ FTP.prototype._pasv = function(cb) {
   var self = this, first = true, ip, port;
 
   var pasvCmd = (self._featEpsv && !this.options.forcePasv) ? 'EPSV' : 'PASV';
-  this._send(pasvCmd, function(err, text) {
+  this._send(pasvCmd, function reentry(err, text) {
     if (err)
       return cb(err);
 


### PR DESCRIPTION
Reentry error correction

`
ReferenceError: reentry is not defined
at /app/node_modules/@icetee/ftp/lib/сonnection.js:937:11
at Timeout._onTimeout (/app/node_modules/@icetee/ftp/lib/connection.js:962:9)
at ListOnTimeout (internal/timers.js:531:17)
at processTimers (internal/timers.Js:475:7)
`