### PR TITLE
Fix secure implicit connections in pasv mode

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -134,7 +134,7 @@ FTP.prototype.connect = function(options) {
     noopreq.cb();
   });
 
-  if (this.options.secure) {
+  if (this.options.secure !== false) {
     secureOptions = {};
     secureOptions.host = this.options.host;
     for (var k in this.options.secureOptions)
@@ -978,7 +978,7 @@ FTP.prototype._pasvConnect = function(ip, port, cb) {
 
   socket.once('connect', function() {
     self._debug&&self._debug('[connection] PASV socket connected');
-    if (self.options.secure === true) {
+    if (self.options.secure !== false) {
       self.options.secureOptions.socket = socket;
       self.options.secureOptions.session = self._socket.getSession();
       //socket.removeAllListeners('error');


### PR DESCRIPTION
This issue occurs when you set `secure` to `'implicit'`.

Here is a minimum viable example of the error in action:

client.js:
```js
const fs = require('fs');
const Client = require('@icetee/ftp');

const client = new Client();

client.on('ready', async () => {
    client.list((error, list) => {
        console.info(error || list);
        client.end();
    });
});

client.connect({
    host: 'localhost',
    port: 9876,
    secure: 'implicit',
    secureOptions: {ca: [fs.readFileSync('crts/rootCA.crt')]},
});
```

server.js:
```js
const fs = require('fs');
const FtpServer = require('ftp-srv');

const server = new FtpServer({
    url: 'ftps://127.0.0.1:9876',
    pasv_url: '0.0.0.0',
    tls: {
        cert: fs.readFileSync('crts/server.crt'),
        key: fs.readFileSync('crts/server.key'),
        ca: fs.readFileSync('crts/rootCA.crt'),
    },
});

server.on('login', ({}, resolve) => resolve({}));

server.listen();
```

I think this may be related to this issue, at that was the symptom that this caused for me :eyes:
https://github.com/trs/ftp-srv/issues/192
