### PR TITLE
Fixed rmdir operation with recursion on non-existent directory

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -410,6 +410,10 @@ FTP.prototype.logout = function(cb) {
 
 FTP.prototype.listSafe = function(path, zcomp, cb) {
   if (typeof path === 'string') {
+    if (typeof zcomp === 'function') {
+      cb = zcomp;
+      zcomp = false;
+    }
     var self = this;
     // store current path
     this.pwd(function(err, origpath) {
@@ -785,7 +789,7 @@ FTP.prototype.rmdir = function(path, recursive, cb) { // RMD is optional
   }
 
   var self = this;
-  this.list(path, function(err, list) {
+  this.listSafe(path, function(err, list) {
     if (err) return cb(err);
     var idx = 0;
 


### PR DESCRIPTION
When you call rmdir() with recursive=true on a non-existent directory it causes:

> TypeError: Cannot read property '0' of undefined
    at deleteNextEntry (/opt/noderedftp/lib/node_modules/node-red/nodes/extra/ftp/node_modules/@icetee/ftp/lib/connection.js:808:21)
    at /opt/noderedftp/lib/node_modules/node-red/nodes/extra/ftp/node_modules/@icetee/ftp/lib/connection.js:830:5
    at final (/opt/noderedftp/lib/node_modules/node-red/nodes/extra/ftp/node_modules/@icetee/ftp/lib/connection.js:515:11)
    at Object.cb (/opt/noderedftp/lib/node_modules/node-red/nodes/extra/ftp/node_modules/@icetee/ftp/lib/connection.js:552:11)

rmdir() calls list() which returns "No such file or directory" string instead a error and rmdir() tries to use it as a dir item.

I have replaced list() with listSafe() which is able to return the error, but it has bug too. It doesn't test missing optional arguments. So this patch also solves this issue.
