### PR TITLE
fixed lastMod to interpret MDTM time as GMT

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -881,7 +881,7 @@ FTP.prototype.lastMod = function(path, cb) {
     if (!val)
       return cb(new Error('Invalid date/time format from server'));
     ret = new Date(val.year + '-' + val.month + '-' + val.date + 'T' + val.hour
-                   + ':' + val.minute + ':' + val.second);
+                   + ':' + val.minute + ':' + val.second + 'Z');
     cb(undefined, ret);
   });
 };


### PR DESCRIPTION
The function lastMod relies on the FTP command MDTM. The MDTM command returns time strings that look like 19990929043300 meaning 1999-09-29 04:33:00. According to [RFC 3659](https://www.rfc-editor.org/rfc/rfc3659#page-11) these times are in GMT, which makes sense. However, they were passed directly into the constructor for a Date object, meaning they were interpreted as local time. By adding a Z to the end of the string so it looks like 1999-09-29T04:33:00Z the Date constructor will interpret them correctly.